### PR TITLE
Update `caption-side` values

### DIFF
--- a/css/properties/caption-side.json
+++ b/css/properties/caption-side.json
@@ -43,6 +43,216 @@
             "deprecated": false
           }
         },
+        "top_value": {
+          "__compat": {
+            "description": "<code>top</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "8"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "bottom_value": {
+          "__compat": {
+            "description": "<code>bottom</code> value",
+            "support": {
+              "chrome": {
+                "version_added": "1"
+              },
+              "chrome_android": "mirror",
+              "edge": {
+                "version_added": "12"
+              },
+              "firefox": {
+                "version_added": "1"
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": "8"
+              },
+              "oculus": "mirror",
+              "opera": {
+                "version_added": "4"
+              },
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "1"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": {
+                "version_added": "≤37"
+              }
+            },
+            "status": {
+              "experimental": false,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "block_start_value": {
+          "__compat": {
+            "description": "<code>block-start</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "block_end_value": {
+          "__compat": {
+            "description": "<code>block-end</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline_start_value": {
+          "__compat": {
+            "description": "<code>inline-start</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
+        "inline_end_value": {
+          "__compat": {
+            "description": "<code>inline-end</code> value",
+            "support": {
+              "chrome": {
+                "version_added": false
+              },
+              "chrome_android": "mirror",
+              "edge": "mirror",
+              "firefox": {
+                "version_added": false
+              },
+              "firefox_android": "mirror",
+              "ie": {
+                "version_added": false
+              },
+              "oculus": "mirror",
+              "opera": "mirror",
+              "opera_android": "mirror",
+              "safari": {
+                "version_added": "preview"
+              },
+              "safari_ios": "mirror",
+              "samsunginternet_android": "mirror",
+              "webview_android": "mirror"
+            },
+            "status": {
+              "experimental": true,
+              "standard_track": true,
+              "deprecated": false
+            }
+          }
+        },
         "non_standard_values": {
           "__compat": {
             "description": "Non-standard values <code>left</code>, <code>right</code>, <code>top-outside</code>, and <code>bottom-outside</code>",


### PR DESCRIPTION
#### Summary

This PR adds browser support for each `caption-side` value.

Currently, browser support only the physical `top` and `bottom` values. The logical values are defined in a different spec, and they are not supported yet.

Hopefully this property will be added to "Interop 2024" and browsers will support them soon. Meanwhile, BCD should display compatibility data for each value separately.

#### Current browser support

* [Blink](https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/core/css/css_properties.json5;drc=c704e9e51bc30032bed14d88d009e33459e25884;l=2457)
* [WebKit](https://searchfox.org/wubkat/rev/5dfffd1d9c0cdf683b9302cd72303bf9e6700921/Source/WebCore/rendering/style/RenderStyleConstants.h#755)
* [Gecko](https://searchfox.org/mozilla-central/rev/90dce6b0223b4dc17bb10f1125b44f70951585f9/servo/components/style/values/specified/table.rs#33)

#### Related issues

* https://github.com/web-platform-tests/interop/issues/434#issuecomment-1811325362
* https://github.com/web-platform-tests/interop/issues/434#issuecomment-1811987666
